### PR TITLE
Install update

### DIFF
--- a/docs/Install Ubuntu Linux.md
+++ b/docs/Install Ubuntu Linux.md
@@ -49,16 +49,16 @@
 
 
 - To install infertrade specifically for the required version of python (v3.7).
-```
-python3.7 -m pip install infertrade
-```
+  ```
+  python3.7 -m pip install infertrade
+  ```
 
 - Your python program may give you a dependency related error when running Infertade module or not be loading other relevant modules like pandas, even after installing them with pip3. 
 
-In this case you want to use the same procedure as above.
-```
-python3.7 -m pip install pandas
-```
+  In this case you want to use the same procedure as above.
+  ```
+  python3.7 -m pip install pandas
+  ```
 <br>
 
 ## Testing using PyTest.


### PR DESCRIPTION
I found pip3 could give environmental issues when installing Infertrade. 

With python 3.7 everything works as expected as long as the version can read the relevant modules. I expanded the Installation documentation  so it includes how to do it as well. It did fix the problem in the machine I found the problem with.

I though made more sense to have it in the install instruction in case the problem arises when doing it than having it in the troubleshooting section.