### PR TITLE
Add 1bp and 20 day realised vol minimum floors to volatility

### DIFF
--- a/infertrade/utilities/operations.py
+++ b/infertrade/utilities/operations.py
@@ -612,7 +612,7 @@ def calculate_regression_with_kelly_optimum(
                         raise ZeroDivisionError("Volatility needs to be positive value.")
 
                     # Flooring volatility at last 20 step recent volatility.
-                    recent_fractional_realised_vol = np.std(regression_period_price_change.diff(1)[-20:])
+                    recent_fractional_realised_vol = np.std(regression_period_price_change[-20:])
                     if volatility < recent_fractional_realised_vol:
                         volatility = recent_fractional_realised_vol
                         

--- a/infertrade/utilities/operations.py
+++ b/infertrade/utilities/operations.py
@@ -612,14 +612,15 @@ def calculate_regression_with_kelly_optimum(
                         raise ZeroDivisionError("Volatility needs to be positive value.")
 
                     # Flooring volatility at last 20 step recent volatility.
-                    recent_fractional_realised_vol = np.std(regression_period_price_change[-20:])
+                    window_length_recent_vol = 20
+                    recent_fractional_realised_vol = np.std(regression_period_price_change[-window_length_recent_vol:])
                     if volatility < recent_fractional_realised_vol:
                         volatility = recent_fractional_realised_vol
                         
                     # Absolute floor for volatility at 0.01% == 1bp
                     minimum_volatility = 0.0001
-                    if volatility < 0.0001:
-                        volatility = 0.0001
+                    if volatility < minimum_volatility:
+                        volatility = minimum_volatility
 
                     # Calculate Kelly fraction to invest
                     kelly_recommended_optimum = forecast_price_change / volatility ** 2


### PR DESCRIPTION

Currently the raw regressions can generate very high fractional investments for sticky prices. Although this is primarily a data quality issue, imposing a minimum floor on volatility is advisible.

![image](https://user-images.githubusercontent.com/29981664/142287084-40dbb937-1a7f-40aa-94f2-fe1b4f845bc9.png)
